### PR TITLE
Changed for yaml.load to utilize loader and bypass warning

### DIFF
--- a/Demos/02-add-aad-auth/graph_tutorial/tutorial/auth_helper.py
+++ b/Demos/02-add-aad-auth/graph_tutorial/tutorial/auth_helper.py
@@ -14,7 +14,7 @@ os.environ['OAUTHLIB_IGNORE_SCOPE_CHANGE'] = '1'
 
 # Load the oauth_settings.yml file
 stream = open('oauth_settings.yml', 'r')
-settings = yaml.load(stream)
+settings = yaml.load(stream, yaml.SafeLoader)
 authorize_url = '{0}{1}'.format(settings['authority'], settings['authorize_endpoint'])
 token_url = '{0}{1}'.format(settings['authority'], settings['token_endpoint'])
 

--- a/Demos/03-add-msgraph/graph_tutorial/tutorial/auth_helper.py
+++ b/Demos/03-add-msgraph/graph_tutorial/tutorial/auth_helper.py
@@ -14,7 +14,7 @@ os.environ['OAUTHLIB_IGNORE_SCOPE_CHANGE'] = '1'
 
 # Load the oauth_settings.yml file
 stream = open('oauth_settings.yml', 'r')
-settings = yaml.load(stream)
+settings = yaml.load(stream, yaml.SafeLoader)
 authorize_url = '{0}{1}'.format(settings['authority'], settings['authorize_endpoint'])
 token_url = '{0}{1}'.format(settings['authority'], settings['token_endpoint'])
 

--- a/tutorial/add-aad-auth.md
+++ b/tutorial/add-aad-auth.md
@@ -40,7 +40,7 @@ os.environ['OAUTHLIB_IGNORE_SCOPE_CHANGE'] = '1'
 
 # Load the oauth_settings.yml file
 stream = open('oauth_settings.yml', 'r')
-settings = yaml.load(stream)
+settings = yaml.load(stream, yaml.SafeLoader)
 authorize_url = '{0}{1}'.format(settings['authority'], settings['authorize_endpoint'])
 token_url = '{0}{1}'.format(settings['authority'], settings['token_endpoint'])
 


### PR DESCRIPTION
It is no longer considered safe for yaml.load to be utilized without specifying loader