### PR TITLE
Fixed error when user time zone isn't set

### DIFF
--- a/demo/graph_tutorial/tutorial/auth_helper.py
+++ b/demo/graph_tutorial/tutorial/auth_helper.py
@@ -63,7 +63,7 @@ def store_user(request, user):
       'is_authenticated': True,
       'name': user['displayName'],
       'email': user['mail'] if (user['mail'] != None) else user['userPrincipalName'],
-      'timeZone': user['mailboxSettings']['timeZone'] if (user['mailboxSettings']['timeZone'] != None) else 'UTC'
+      'timeZone': user['mailboxSettings']['timeZone'] if ('timeZone' in user['mailboxSettings']) else 'UTC'
     }
   except Exception as e:
     print(e)


### PR DESCRIPTION
Changed to check if `timeZone` key is present in `mailboxSettings`, rather than checking if it is None.

Fixes #79